### PR TITLE
Disable composer script timeout

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -148,6 +148,7 @@ class InstallCommand extends Command
         $content['scripts']['build'] = '@php vendor/bin/testbench workbench:build --ansi';
         $content['scripts']['serve'] = [
             '@build',
+            'Composer\\Config::disableProcessTimeout', 
             '@php vendor/bin/testbench serve',
         ];
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -147,8 +147,8 @@ class InstallCommand extends Command
 
         $content['scripts']['build'] = '@php vendor/bin/testbench workbench:build --ansi';
         $content['scripts']['serve'] = [
-            '@build',
             'Composer\\Config::disableProcessTimeout',
+            '@build',
             '@php vendor/bin/testbench serve',
         ];
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -148,7 +148,7 @@ class InstallCommand extends Command
         $content['scripts']['build'] = '@php vendor/bin/testbench workbench:build --ansi';
         $content['scripts']['serve'] = [
             '@build',
-            'Composer\\Config::disableProcessTimeout', 
+            'Composer\\Config::disableProcessTimeout',
             '@php vendor/bin/testbench serve',
         ];
 


### PR DESCRIPTION
### Fixed

- I recently recorded a screencast using the Workbench app and the process kept "dying" after 5mins. I think we could disable timeouts ([Composer docs](https://getcomposer.org/doc/06-config.md#process-timeout))